### PR TITLE
move php, mariadb, and nginx config into image builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## June 29, 2022 (DESCW(443))
+- Move php config into wordpress docker build.
+- Move mariadb config into mariadb docker build.
+- Move nginx config into nginx docker build.
+
 ## June 28, 2022 (DESCW(433))
 - Dependabot monitoring for docker images.
 

--- a/openshift/templates/config/config.yaml
+++ b/openshift/templates/config/config.yaml
@@ -3,7 +3,7 @@ apiVersion: template.openshift.io/v1
 metadata:
   name: wordpress-configuration
   annotations:
-    openshift.io/display-name:  Configuration templates for the WordPress deploy.
+    openshift.io/display-name: Configuration templates for the WordPress deploy.
     description: Configuration templates for the WordPress  deploy.
     tags: mariadb,wordpress,php,nginx
 
@@ -28,9 +28,6 @@ parameters:
     description: "The name for this environment [dev, test, prod, tools]"
     required: true
     value: "dev"
-  - name: MAX_FILE_SIZE
-    displayName: "The max file size for upload"
-    value: "512M"
 
   - name: APP_DOMAIN
     displayName: "Application Hostname"
@@ -66,7 +63,7 @@ objects:
       MYSQL_USER: ${SITE_NAME}_user
       MYSQL_DATABASE: ${SITE_NAME}_${ENV_NAME}
       # Backups
-      backup.conf: 'mariadb=${APP_NAME}-mariadb--${SITE_NAME}:3306/${SITE_NAME}_${ENV_NAME}'
+      backup.conf: "mariadb=${APP_NAME}-mariadb--${SITE_NAME}:3306/${SITE_NAME}_${ENV_NAME}"
       # WordPress
       WORDPRESS_DB_HOST: ${APP_NAME}-mariadb--${SITE_NAME}
       WORDPRESS_DB_PASSWORD_FILE: /run/secrets/WORDPRESS_DB_PASSWORD
@@ -98,66 +95,3 @@ objects:
       WORDPRESS_NONCE_SALT_FILE: /run/secrets/wordpress/WORDPRESS_NONCE_SALT
       WORDPRESS_SECURE_AUTH_KEY_FILE: /run/secrets/wordpress/WORDPRESS_SECURE_AUTH_KEY
       WORDPRESS_SECURE_AUTH_SALT_FILE: /run/secrets/wordpress/WORDPRESS_SECURE_AUTH_SALT
-      # PHP configuration [to be moved to image build]
-      app.ini: |-
-        upload_max_filesize=${MAX_FILE_SIZE}
-        post_max_size=${MAX_FILE_SIZE}
-        memory_limit=256M
-        max_execution_time=300
-        max_input_time=300
-      # Maria DB configuration [to be moved to image build]
-      my.cnf: |-
-        [mariadb]
-        innodb_buffer_pool_size = 10M
-        innodb_log_buffer_size = 512K # default / 2
-        innodb_log_file_size = 8M
-        lower_case_table_names = 1
-        key_buffer_size = 4194304 # default / 2
-      # Ngnix configuration [to be moved to image build]
-      default.conf: |-
-        server {
-          index index.php index.html;
-          server_name localhost;
-          #listen 8443 ssl;
-          listen 8080;
-          error_log  /dev/stderr;
-          access_log /dev/stdout;
-          root /var/www/html/;
-          # Sets Nginx max file upload size;
-          client_max_body_size 1000M;
-
-          location ~ /\. {
-              return 404;
-              deny all;
-          }
-
-          location / {
-              try_files $uri $uri/ /index.php?$args; 
-          }
-          # Required for multi-site wp-admin.
-          if (!-e $request_filename) {
-              rewrite /wp-admin$ $scheme://$host$uri/ permanent;  
-              rewrite ^(/[^/]+)?(/wp-.*) $2 last;                     
-              rewrite ^(/[^/]+)?(/.*.php) $2 last;                   
-          }
-          location /nginx_status {
-              stub_status on;
-              access_log off;
-              log_not_found off;
-              allow 127.0.0.1;
-              deny all;
-          }
-
-          location ~ \.php$ {
-              try_files $uri =404;
-              fastcgi_split_path_info ^(.+\.php)(/.+)$;
-              fastcgi_pass 127.0.0.1:9000;
-              fastcgi_index index.php;
-              include fastcgi_params;
-              fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-              fastcgi_param PATH_INFO $fastcgi_path_info;
-              fastcgi_param SERVER_NAME $server_name; 
-          }
-
-        }
-      

--- a/openshift/templates/images/mariadb/docker-compose.yaml
+++ b/openshift/templates/images/mariadb/docker-compose.yaml
@@ -1,7 +1,13 @@
-version: '3.1'
+version: "3.1"
 services:
   db:
     build: ./docker
     user: "1002:1001"
     environment:
       MARIADB_ROOT_PASSWORD: password
+    command: >-
+      mariadb --innodb-buffer-pool-size=10M
+      --innodb_log_buffer_size=512K
+      --innodb_log_file_size = 8M
+      --lower_case_table_names = 1
+      --key_buffer_size = 4194304

--- a/openshift/templates/images/nginx/docker/Dockerfile
+++ b/openshift/templates/images/nginx/docker/Dockerfile
@@ -11,4 +11,6 @@ HEALTHCHECK --start-period=5s CMD pgrep nginx
 
 VOLUME ["/var/www/html", "/var/log/nginx"]
 
+COPY docker/default.conf /etc/nginx/default.conf
+
 EXPOSE 80 443

--- a/openshift/templates/images/nginx/docker/default.conf
+++ b/openshift/templates/images/nginx/docker/default.conf
@@ -1,0 +1,45 @@
+server {
+          index index.php index.html;
+          server_name localhost;
+          #listen 8443 ssl;
+          listen 8080;
+          error_log  /dev/stderr;
+          access_log /dev/stdout;
+          root /var/www/html/;
+          # Sets Nginx max file upload size;
+          client_max_body_size 1000M;
+
+          location ~ /\. {
+              return 404;
+              deny all;
+          }
+
+          location / {
+              try_files $uri $uri/ /index.php?$args; 
+          }
+          # Required for multi-site wp-admin.
+          if (!-e $request_filename) {
+              rewrite /wp-admin$ $scheme://$host$uri/ permanent;  
+              rewrite ^(/[^/]+)?(/wp-.*) $2 last;                     
+              rewrite ^(/[^/]+)?(/.*.php) $2 last;                   
+          }
+          location /nginx_status {
+              stub_status on;
+              access_log off;
+              log_not_found off;
+              allow 127.0.0.1;
+              deny all;
+          }
+
+          location ~ \.php$ {
+              try_files $uri =404;
+              fastcgi_split_path_info ^(.+\.php)(/.+)$;
+              fastcgi_pass 127.0.0.1:9000;
+              fastcgi_index index.php;
+              include fastcgi_params;
+              fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+              fastcgi_param PATH_INFO $fastcgi_path_info;
+              fastcgi_param SERVER_NAME $server_name; 
+          }
+
+        }

--- a/openshift/templates/images/wordpress/docker/Dockerfile
+++ b/openshift/templates/images/wordpress/docker/Dockerfile
@@ -1,7 +1,18 @@
 FROM wordpress:6.0.0-php7.4-fpm-alpine
 # Install LDAP for Next Active Directory Integration Plugin.
 RUN set -ex; \
-	apk add --no-cache --virtual .build-deps \
+        apk add --no-cache --virtual .build-deps \
         openldap-dev; \
-	docker-php-ext-install ldap; \
-    docker-php-ext-enable ldap; \
+        docker-php-ext-install ldap; \
+        docker-php-ext-enable ldap;
+
+RUN mv /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini; \
+        rm /usr/local/etc/php/php.ini-development; \
+        sed -i -e 's/memory_limit\ =\ 128M/memory_limit\ =\ 256M/g' /usr/local/etc/php/php.ini;
+
+RUN touch /usr/local/etc/php/conf.d/uploads.ini \
+        && echo "upload_max_filesize = 512M;" >> /usr/local/etc/php/conf.d/uploads.ini \
+        && echo "post_max_size = 512M;" >> /usr/local/etc/php/conf.d/uploads.ini;
+
+RUN sed -i 's/max_execution_time = 30/max_execution_time = 300/' /usr/local/etc/php/php.ini \
+        && sed -i 's/max_input_time = 30/max_input_time = 300/' /usr/local/etc/php/php.ini;


### PR DESCRIPTION
[DESCW-443](https://apps.itsm.gov.bc.ca/jira/browse/DESCW-443) Part 1 of 2: This PR does not include wordpress variable clean up. Want to make sure I'm on the right track before continuing.

Feedback request for reviewers: are there better practices for including these configuration settings in the builds?