### PR TITLE
upgrade wordpress to 6.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## September 15 2022 (DESCW-593)
+- Upgrade wordpress to use v6.0.2
+
 ## July 27, 2022 (DESSO-467)
 - Fixed Nginx config directory
 - Added nginx.conf configmap mount for nginx site specific overrides.

--- a/openshift/templates/README.md
+++ b/openshift/templates/README.md
@@ -32,7 +32,7 @@ Create [build images](./images/README.md)
 | alpine | 3.15.4 | Base Alpine linux |
 | mariadb | 10.6.8-r0 | MariaDB version that gets build in base-images via Dockerfile. Dependent on the [Alpine version](https://pkgs.alpinelinux.org/packages?name=mariadb&branch=v3.15): |
 | nginx | 1.23.1-alpine | Nginx web server, used to serve WordPress / PHP |
-| wordpress | 6.0.0-php7.4-fpm-alpine | PHP-FPM for WordPress |
+| wordpress | 6.0.2-php7.4-fpm-alpine | PHP-FPM for WordPress |
 | ubuntu | 22.04| Used for the sidecar |
 
 ## Image references

--- a/openshift/templates/dockerhub-imagestreams/README.md
+++ b/openshift/templates/dockerhub-imagestreams/README.md
@@ -12,7 +12,7 @@ This remediates the issue with restrictions from dockerhub.
 
 ### WordPress image with php-fpm
 * Used as an initial php-fpm base, then adds php configs for WordPress, then gets used for WordPress.
-* wordpress:6.0.0-php7.4-fpm-alpine
+* wordpress:6.0.2-php7.4-fpm-alpine
   * `oc process -f openshift/templates/dockerhub-imagestreams/wordpress.yaml | oc apply -f -`
 
 ### Nginx

--- a/openshift/templates/dockerhub-imagestreams/wordpress.yaml
+++ b/openshift/templates/dockerhub-imagestreams/wordpress.yaml
@@ -33,7 +33,7 @@ parameters:
   - name: IMAGE_TAG
     displayName: "The WordPress image tag"
     description: "This is the official image tag, which is later used to build the wordpress-wordpress-run"
-    value: "6.0.0-php7.4-fpm-alpine"
+    value: "6.0.2-php7.4-fpm-alpine"
 
 objects:
   - kind: ImageStream

--- a/openshift/templates/images/README.md
+++ b/openshift/templates/images/README.md
@@ -25,8 +25,8 @@ Base images are images that would use dockerhub image streams to create an addit
 * verify image `docker run -it wordpress-nginx-run:dev sh`
 
 ### WordPress
-* Creates WordPress core 6.0.0
-* wordpress:6.0.0-php7.4-fpm-alpine -> wordpress-wordpress-run
+* Creates WordPress core 6.0.2
+* wordpress:6.0.2-php7.4-fpm-alpine -> wordpress-wordpress-run
   * `oc process -f openshift/templates/images/wordpress/build.yaml | oc apply -f -`
 
 ### Sidecar

--- a/openshift/templates/images/wordpress/docker/Dockerfile
+++ b/openshift/templates/images/wordpress/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM wordpress:6.0.0-php7.4-fpm-alpine
+FROM wordpress:6.0.2-php7.4-fpm-alpine
 # Install LDAP for Next Active Directory Integration Plugin.
 RUN set -ex; \
         apk add --no-cache --virtual .build-deps \


### PR DESCRIPTION
[DESCW-593](https://apps.itsm.gov.bc.ca/jira/browse/DESCW-593)
Upgrades WordPress from 6.0.0 -> 6.0.2