### PR TITLE
updated configmap for mariadb backup cronjobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## June 14, 2023 (DESCW-1237)
+- Fixed volume config map for the mariadb backup cronjob, which was causing the backup job to fail.
+
 ## June 8, 2023 (DESCW-1189)
 - update wordpress to 6.2.2
 - fix bug caused by redhat dependency update

--- a/openshift/templates/backups/cron.yaml
+++ b/openshift/templates/backups/cron.yaml
@@ -117,7 +117,7 @@ objects:
                     claimName: ${APP_NAME}-backup-verification
                 - name: ${APP_NAME}-mariadb-backup-file-config
                   configMap:
-                    name: ${APP_NAME}-mariadb-backup-file-config--${SITE_NAME}
+                    name: ${APP_NAME}-config--${SITE_NAME}
                     items:
                       - key: backup.conf
                         path: backup.conf


### PR DESCRIPTION
The config map for the volumes was incorrect.

This has been tested by running:
```bash
oc process -p ENV_NAME=prod -p SITE_NAME=cloud -p POOL_NAME=pool-beta -f openshift/templates/backups/cron.yaml | oc apply -f -

oc create job --from=cronjobs/wordpress-mariadb-cron--cloud wordpress-mariadb-cron--cloud-test
``` 