### PR TITLE
Fixed wrong option name (max_post_size) in php.conf.ini

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+
+## September 07, 2023 (DESCW-1465)
+- Fixed wrong option name (max_post_size) in php.conf.ini
 ## August 17, 2023 (DESCW-1428)
 - update wordpress to 6.3.0
 ## June 14, 2023 (DESCW-1237)

--- a/openshift/templates/images/wordpress/docker/php.conf.ini
+++ b/openshift/templates/images/wordpress/docker/php.conf.ini
@@ -1,5 +1,5 @@
 memory_limit = 256M
 upload_max_filesize = 512M
-post_max_filesize = 512M
+post_max_size = 512M
 max_execution_time = 300
 max_input_time = 300


### PR DESCRIPTION
php.conf.ini was using the wrong name for the max_post_size option (see https://www.php.net/manual/en/ini.core.php#ini.post-max-size) causing it not to be used.