### PR TITLE
[DESCW-2368] Updated dev deployment to allow WordPress unit tests to be run inside…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Created two new commands to support the above:
   - `wp_setup_tests`: Runs the WP-provided script to install test files and set up the test database.
   - `wp_test`: Runs unit tests on the current directory.
+- **NOTE:** Run `docker compose down` and `docker compose up --build` to get these changes if you already have this deployment running.
 
 ## February 29, 2024
 - Updated local WordPress Deployment

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 # Changelog
+
+## May 31, 2024
+- Updated dev deployment to allow WordPress unit tests to be run inside the PHP Wordpress container.
+- Created two new commands to support the above:
+  - `wp_setup_tests`: Runs the WP-provided script to install test files and set up the test database.
+  - `wp_test`: Runs unit tests on the current directory.
+
 ## February 29, 2024
 - Updated local WordPress Deployment
   - auto updates 3rd party plugins to minor versions.

--- a/dev/bin/commands.sh
+++ b/dev/bin/commands.sh
@@ -34,6 +34,20 @@ wp() {
 wp_audit() {
     source "${ROOT_PATH}bin/wpaudit.sh"
 }
+
+# Set up WordPress unit testing environment
+wp_setup_tests() {
+    docker exec -it dev-wordpress-php-fpm-1 /bin/sh -c "/usr/bin/setup-tests.sh wordpress_test root ${MYSQL_ROOT_PASSWORD} ${MYSQL_HOST}"
+}
+
+# Perform WordPress PHP unit tests on the current directory
+# Should be used from a theme or plugin project's root
+wp_test() {
+    docker exec \
+    -w /var/www/html/wp-content/${PWD//$CONTENT_DIR/} \
+    -it dev-wordpress-php-fpm-1 \
+    vendor/bin/phpunit --configuration phpunit.xml.dist
+}
     
 # Goes to either the plugin directory or theme directory
 gowp() {
@@ -44,10 +58,9 @@ gowp() {
 
 # php composer docker instance https://hub.docker.com/_/composer
 wp_composer() {
-  docker run --rm --interactive --tty \
-  --volume $PWD:/app \
-  composer:latest $@
-
+    docker run --rm --interactive --tty \
+    --volume $PWD:/app \
+    composer:latest $@
 }
 
 # Searches WordPress ,but excludes certain directories.

--- a/dev/bin/setup-tests.sh
+++ b/dev/bin/setup-tests.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+
+# This file is created automatically when running WP-CLI command "wp scaffold plugin-tests".
+# It downloads the WordPress test files and starts a database used during unit tests.
+# See: https://developer.wordpress.org/cli/commands/scaffold/plugin-tests/
+
+if [ $# -lt 3 ]; then
+	echo "usage: $0 <db-name> <db-user> <db-pass> [db-host] [wp-version] [skip-database-creation]"
+	exit 1
+fi
+
+DB_NAME=$1
+DB_USER=$2
+DB_PASS=$3
+DB_HOST=${4-localhost}
+WP_VERSION=${5-latest}
+SKIP_DB_CREATE=${6-false}
+
+TMPDIR=${TMPDIR-/tmp}
+TMPDIR=$(echo $TMPDIR | sed -e "s/\/$//")
+WP_TESTS_DIR=${WP_TESTS_DIR-$TMPDIR/wordpress-tests-lib}
+WP_CORE_DIR=${WP_CORE_DIR-$TMPDIR/wordpress}
+
+download() {
+    if [ `which curl` ]; then
+        curl -s "$1" > "$2";
+    elif [ `which wget` ]; then
+        wget -nv -O "$2" "$1"
+    fi
+}
+
+if [[ $WP_VERSION =~ ^[0-9]+\.[0-9]+\-(beta|RC)[0-9]+$ ]]; then
+	WP_BRANCH=${WP_VERSION%\-*}
+	WP_TESTS_TAG="branches/$WP_BRANCH"
+
+elif [[ $WP_VERSION =~ ^[0-9]+\.[0-9]+$ ]]; then
+	WP_TESTS_TAG="branches/$WP_VERSION"
+elif [[ $WP_VERSION =~ [0-9]+\.[0-9]+\.[0-9]+ ]]; then
+	if [[ $WP_VERSION =~ [0-9]+\.[0-9]+\.[0] ]]; then
+		# version x.x.0 means the first release of the major version, so strip off the .0 and download version x.x
+		WP_TESTS_TAG="tags/${WP_VERSION%??}"
+	else
+		WP_TESTS_TAG="tags/$WP_VERSION"
+	fi
+elif [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
+	WP_TESTS_TAG="trunk"
+else
+	# http serves a single offer, whereas https serves multiple. we only want one
+	download http://api.wordpress.org/core/version-check/1.7/ /tmp/wp-latest.json
+	grep '[0-9]+\.[0-9]+(\.[0-9]+)?' /tmp/wp-latest.json
+	LATEST_VERSION=$(grep -o '"version":"[^"]*' /tmp/wp-latest.json | sed 's/"version":"//')
+	if [[ -z "$LATEST_VERSION" ]]; then
+		echo "Latest WordPress version could not be found"
+		exit 1
+	fi
+	WP_TESTS_TAG="tags/$LATEST_VERSION"
+fi
+set -ex
+
+install_wp() {
+
+	if [ -d $WP_CORE_DIR ]; then
+		return;
+	fi
+
+	mkdir -p $WP_CORE_DIR
+
+	if [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
+		mkdir -p $TMPDIR/wordpress-trunk
+		rm -rf $TMPDIR/wordpress-trunk/*
+		svn export --quiet https://core.svn.wordpress.org/trunk $TMPDIR/wordpress-trunk/wordpress
+		mv $TMPDIR/wordpress-trunk/wordpress/* $WP_CORE_DIR
+	else
+		if [ $WP_VERSION == 'latest' ]; then
+			local ARCHIVE_NAME='latest'
+		elif [[ $WP_VERSION =~ [0-9]+\.[0-9]+ ]]; then
+			# https serves multiple offers, whereas http serves single.
+			download https://api.wordpress.org/core/version-check/1.7/ $TMPDIR/wp-latest.json
+			if [[ $WP_VERSION =~ [0-9]+\.[0-9]+\.[0] ]]; then
+				# version x.x.0 means the first release of the major version, so strip off the .0 and download version x.x
+				LATEST_VERSION=${WP_VERSION%??}
+			else
+				# otherwise, scan the releases and get the most up to date minor version of the major release
+				local VERSION_ESCAPED=`echo $WP_VERSION | sed 's/\./\\\\./g'`
+				LATEST_VERSION=$(grep -o '"version":"'$VERSION_ESCAPED'[^"]*' $TMPDIR/wp-latest.json | sed 's/"version":"//' | head -1)
+			fi
+			if [[ -z "$LATEST_VERSION" ]]; then
+				local ARCHIVE_NAME="wordpress-$WP_VERSION"
+			else
+				local ARCHIVE_NAME="wordpress-$LATEST_VERSION"
+			fi
+		else
+			local ARCHIVE_NAME="wordpress-$WP_VERSION"
+		fi
+		download https://wordpress.org/${ARCHIVE_NAME}.tar.gz  $TMPDIR/wordpress.tar.gz
+		tar --strip-components=1 -zxmf $TMPDIR/wordpress.tar.gz -C $WP_CORE_DIR
+	fi
+
+	download https://raw.github.com/markoheijnen/wp-mysqli/master/db.php $WP_CORE_DIR/wp-content/db.php
+}
+
+install_test_suite() {
+	# portable in-place argument for both GNU sed and Mac OSX sed
+	if [[ $(uname -s) == 'Darwin' ]]; then
+		local ioption='-i.bak'
+	else
+		local ioption='-i'
+	fi
+
+	# set up testing suite if it doesn't yet exist
+	if [ ! -d $WP_TESTS_DIR ]; then
+		# set up testing suite
+		mkdir -p $WP_TESTS_DIR
+		rm -rf $WP_TESTS_DIR/{includes,data}
+		svn export --quiet --ignore-externals https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/includes/ $WP_TESTS_DIR/includes
+		svn export --quiet --ignore-externals https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/data/ $WP_TESTS_DIR/data
+	fi
+
+	if [ ! -f wp-tests-config.php ]; then
+		download https://develop.svn.wordpress.org/${WP_TESTS_TAG}/wp-tests-config-sample.php "$WP_TESTS_DIR"/wp-tests-config.php
+		# remove all forward slashes in the end
+		WP_CORE_DIR=$(echo $WP_CORE_DIR | sed "s:/\+$::")
+		sed $ioption "s:dirname( __FILE__ ) . '/src/':'$WP_CORE_DIR/':" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s:__DIR__ . '/src/':'$WP_CORE_DIR/':" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s/youremptytestdbnamehere/$DB_NAME/" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s/yourusernamehere/$DB_USER/" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s/yourpasswordhere/$DB_PASS/" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s|localhost|${DB_HOST}|" "$WP_TESTS_DIR"/wp-tests-config.php
+	fi
+
+}
+
+recreate_db() {
+	shopt -s nocasematch
+	if [[ $1 =~ ^(y|yes)$ ]]
+	then
+		mysqladmin drop $DB_NAME -f --user="$DB_USER" --password="$DB_PASS"$EXTRA
+		create_db
+		echo "Recreated the database ($DB_NAME)."
+	else
+		echo "Leaving the existing database ($DB_NAME) in place."
+	fi
+	shopt -u nocasematch
+}
+
+create_db() {
+	mysqladmin create $DB_NAME --user="$DB_USER" --password="$DB_PASS"$EXTRA
+}
+
+install_db() {
+
+	if [ ${SKIP_DB_CREATE} = "true" ]; then
+		return 0
+	fi
+
+	# parse DB_HOST for port or socket references
+	local PARTS=(${DB_HOST//\:/ })
+	local DB_HOSTNAME=${PARTS[0]};
+	local DB_SOCK_OR_PORT=${PARTS[1]};
+	local EXTRA=""
+
+	if ! [ -z $DB_HOSTNAME ] ; then
+		if [ $(echo $DB_SOCK_OR_PORT | grep -e '^[0-9]\{1,\}$') ]; then
+			EXTRA=" --host=$DB_HOSTNAME --port=$DB_SOCK_OR_PORT --protocol=tcp"
+		elif ! [ -z $DB_SOCK_OR_PORT ] ; then
+			EXTRA=" --socket=$DB_SOCK_OR_PORT"
+		elif ! [ -z $DB_HOSTNAME ] ; then
+			EXTRA=" --host=$DB_HOSTNAME --protocol=tcp"
+		fi
+	fi
+
+	# create database
+	if [ $(mysql --user="$DB_USER" --password="$DB_PASS"$EXTRA --execute='show databases;' | grep ^$DB_NAME$) ]
+	then
+		echo "Reinstalling will delete the existing test database ($DB_NAME)"
+		read -p 'Are you sure you want to proceed? [y/N]: ' DELETE_EXISTING_DB
+		recreate_db $DELETE_EXISTING_DB
+	else
+		create_db
+	fi
+}
+
+install_wp
+install_test_suite
+install_db

--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -105,6 +105,9 @@ services:
     build:
       context: ../openshift/templates/images/wordpress/docker
     environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      WP_CORE_DIR: /var/www/html/
+      TMPDIR: /tmp/WordPress
       WORDPRESS_DB_HOST: ${MYSQL_HOST}
       WORDPRESS_DB_USER: ${MYSQL_USER}
       WORDPRESS_DB_PASSWORD: ${MYSQL_PASSWORD}
@@ -127,6 +130,7 @@ services:
       - /var/www/html
       - ${CONTENT_DIR}:/var/www/html/wp-content/
       - ${TEMP_DIR:-~/tmp/WordPress}:/tmp/WordPress:rw
+      - ./bin/setup-tests.sh:/usr/bin/setup-tests.sh
     networks:
       - wp_deploy
     depends_on:

--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3.8"
 # docker compose --env-file .env up --build site --force-recreate
 networks:
   wp_deploy:
@@ -104,6 +103,7 @@ services:
           memory: 100M
     build:
       context: ../openshift/templates/images/wordpress/docker
+      dockerfile: dev.Dockerfile
     environment:
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
       WP_CORE_DIR: /var/www/html/

--- a/documentation/docs/guide/GettingStarted/deploy_locally.md
+++ b/documentation/docs/guide/GettingStarted/deploy_locally.md
@@ -125,6 +125,8 @@ Once this is done you can use the following commands from any directory
 - `wp_log` - Tails the debug.log in the content directory
 - `gowp` - Goes to plugin directory
 - `gowp themes` - Goes to themes directory
+- `wp_setup_tests` - Sets up WordPress unit testing environment.
+- `wp_test` - Runs unit tests from the current directory.
 - `wpgrep` - Does a grep with certain excludes to directories like .git, node_modules, vendor
 - `wp_composer` - Runs the latest php composer
 - `wp` - [Wordpress Command line](https://wp-cli.org/) that allows an endless amount of things to be completed with your local WordPress instance.
@@ -154,3 +156,22 @@ This command will replace your entire database, before running `wp db import` ma
 ```sh:no-line-numbers
 wp db import /tmp/WordPress/all-sites.sql
 ```
+
+## Unit tests
+
+`wp-cli` provides [a way to set up and perform unit/integration tests](https://developer.wordpress.org/cli/commands/scaffold/plugin-tests/) in WordPress' official testing environment.
+If a plugin has been configured to use this method of unit testing, we can run those tests inside this docker deployment.
+
+### Setup
+
+To set up the WP testing environment inside the WordPress container, run the command `wp_setup_tests` from anywhere.
+
+If you get an error saying `command not found: wp_setup_tests`, follow the steps in the "Helper functions" section above.
+
+### Running tests
+
+To run a test:
+1. Navigate to the plugin you want to execute tests on.
+2. Run the command `wp_test`.
+   - If you get a message saying "No tests executed" the plugin is most likely not configured using the `wp scaffold plugin-tests` command so its tests cannot be executed this way. Run the unit tests locally instead (`composer run test`).
+   - If you get a message saying "Have you run bin/install-wp-tests.sh?" you will need to run the `wp_setup_tests` command, then try again.

--- a/documentation/docs/guide/GettingStarted/deploy_locally.md
+++ b/documentation/docs/guide/GettingStarted/deploy_locally.md
@@ -125,7 +125,7 @@ Once this is done you can use the following commands from any directory
 - `wp_log` - Tails the debug.log in the content directory
 - `gowp` - Goes to plugin directory
 - `gowp themes` - Goes to themes directory
-- `wp_setup_tests` - Sets up WordPress unit testing environment.
+- `wp_setup_tests` - Sets up WordPress unit testing environment. See the Unit tests section below for instructions.
 - `wp_test` - Runs unit tests from the current directory.
 - `wpgrep` - Does a grep with certain excludes to directories like .git, node_modules, vendor
 - `wp_composer` - Runs the latest php composer
@@ -161,6 +161,8 @@ wp db import /tmp/WordPress/all-sites.sql
 
 `wp-cli` provides [a way to set up and perform unit/integration tests](https://developer.wordpress.org/cli/commands/scaffold/plugin-tests/) in WordPress' official testing environment.
 If a plugin has been configured to use this method of unit testing, we can run those tests inside this docker deployment.
+
+The WordPress Docker instance must be up and running to use the `wp_setup_tests` or `wp_test` commands (run `wp_start` to start the Docker instance).
 
 ### Setup
 

--- a/openshift/templates/images/wordpress/docker/Dockerfile
+++ b/openshift/templates/images/wordpress/docker/Dockerfile
@@ -8,3 +8,6 @@ RUN set -ex; \
         docker-php-ext-enable ldap;
 
 COPY php.conf.ini /usr/local/etc/php/conf.d/php.ini
+
+RUN apk add subversion
+RUN apk add mysql mysql-client

--- a/openshift/templates/images/wordpress/docker/dev.Dockerfile
+++ b/openshift/templates/images/wordpress/docker/dev.Dockerfile
@@ -8,3 +8,7 @@ RUN set -ex; \
         docker-php-ext-enable ldap;
 
 COPY php.conf.ini /usr/local/etc/php/conf.d/php.ini
+
+# Required for installing the WP unit testing environment
+RUN apk add subversion
+RUN apk add mysql mysql-client


### PR DESCRIPTION
Issues with these changes:

- Unit tests are run in PHP8 instead of PHP7 like they are when run locally. This is already causing some test failures in the des-notify-client plugin.
- Coverage reports can't be generated. I think we would need to install xdebug to enable them.
- Doesn't integrate with the wordpress-scripts checklist.