### PR TITLE
Increase client_max_body_size for port 38080 (EEWS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+
+### February 21, 2025
+- Increase nginx `client_max_body_size` for port 38080 (used by NaadConnector/EEWS)
+
 ### January 16, 2025
 - updating Code owners file, to configure requirements of code owner decision ([DESCW-2805](https://citz-gdx.atlassian.net/browse/DESCW-2805))
   

--- a/openshift/templates/images/nginx/docker/local-dev.conf
+++ b/openshift/templates/images/nginx/docker/local-dev.conf
@@ -5,6 +5,7 @@ server {
     listen 38080;
     listen [::]:38080;
     log_not_found off;
+    client_max_body_size 1000M;
     location / {
         proxy_pass https://localhost;
     }


### PR DESCRIPTION
Fixes HTTP status 413 (content too large) for requests sent to port 38080 (used by NaadConnector).